### PR TITLE
XSS vulnerability fix by replacing escape function

### DIFF
--- a/includes/Integration/BunnyNet.php
+++ b/includes/Integration/BunnyNet.php
@@ -190,7 +190,7 @@ class BunnyNet {
 		?>
 		<div class="tutor-video-player">
 			<div style="position: relative; padding-top: 56.25%;">
-				<iframe src="<?php echo esc_attr( $bunny_video_id ); ?>" loading="lazy" style="border: none; position: absolute; top: 0; height: 100%; width: 100%;" allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;" allowfullscreen="true"></iframe>
+				<iframe src="<?php echo esc_url( $bunny_video_id ); ?>" loading="lazy" style="border: none; position: absolute; top: 0; height: 100%; width: 100%;" allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;" allowfullscreen="true"></iframe>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
### Overview

The PR fixes a xss vulnerability located in Bunny net integration plugin allowing user to run arbitary javascript. Looking the issue i have found out that `esc_attr` was used for escaping the url when it should be `esc_url` for escaping. So i have replaced the escape function to escape the url.